### PR TITLE
Minor bugfixes and automation of PyBind11 bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ wrap/
 prog
 *.exe
 venv/
+.idea/
+fortwrap.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 wrap/
 prog
 *.exe
+venv/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+# Current workflow for use with fortwrap_thermopack_demo :
+
+First: `pip install -e .`
+
+Navigate to the `fortwrap_thermopack_demo` directory (from now reffered to as `demo`). 
+
+The script `build.sh` does the following:
+
+ * Compile the Fortran source
+ * Build the archive `libdemo_fortran.a`
+ * Move the archive and `.mod` files to the `demo/wrappers` directory
+ * Run `python -m fortwrap -g -i ../FortWrapOptions.txt` from the `demo/src` directory
+ * Compile the resulting `FortranISOWrappers.f90` and add it to the `libdemo_fortran.a` archive
+ * Compile the `.cpp` files in the `demo/wrappers` directory
+ * Compile `demo/main.cpp`
+
+To build the python wrappings, you must additionally run `cmake ..` from the `demo/wrappers/build` directory.
+
+The `demo/wrappers/CMakeLists.txt` does the following:
+
+ * Define the `pybind_module` target
+ * Add the `demo/wrappers/.cpp` files to the target
+    * It is the binding module `pybind11_bindings.cpp` that is used, not `bindings.cpp`
+ * Link to the archive `libdemo_fortran.a`
+ * Link to `libgfortran.dylib`
+
 # FortWrap
 
 FortWrap is a python script that parses Fortran 90/95/2003 source files and

--- a/README.md
+++ b/README.md
@@ -1,29 +1,3 @@
-# Current workflow for use with fortwrap_thermopack_demo :
-
-First: `pip install -e .`
-
-Navigate to the `fortwrap_thermopack_demo` directory (from now reffered to as `demo`). 
-
-The script `build.sh` does the following:
-
- * Compile the Fortran source
- * Build the archive `libdemo_fortran.a`
- * Move the archive and `.mod` files to the `demo/wrappers` directory
- * Run `python -m fortwrap -g -i ../FortWrapOptions.txt` from the `demo/src` directory
- * Compile the resulting `FortranISOWrappers.f90` and add it to the `libdemo_fortran.a` archive
- * Compile the `.cpp` files in the `demo/wrappers` directory
- * Compile `demo/main.cpp`
-
-To build the python wrappings, you must additionally run `cmake ..` from the `demo/wrappers/build` directory.
-
-The `demo/wrappers/CMakeLists.txt` does the following:
-
- * Define the `pybind_module` target
- * Add the `demo/wrappers/.cpp` files to the target
-    * It is the binding module `pybind11_bindings.cpp` that is used, not `bindings.cpp`
- * Link to the archive `libdemo_fortran.a`
- * Link to `libgfortran.dylib`
-
 # FortWrap
 
 FortWrap is a python script that parses Fortran 90/95/2003 source files and
@@ -36,6 +10,26 @@ the Fortran derived types with C++ "proxy classes".
 Currently, FortWrap is targetted at the gfortran compiler,
 but the generated C++ code should work with any C++ compiler,
 including g++.
+
+# Current working example
+
+FortWrap is being used to develop a Fortran <=> C++ <=> Python wrapper for [ThermoPack](https://github.com/thermotools/thermopack). To see the most up-to-date usage of FortWrap (the `iso_c_bindings` branch at the moment of writing) for this purpose, see the [prototype](https://github.com/thermotools/thermopack/tree/prototype) or [beta_v3](https://github.com/thermotools/thermopack/tree/beta_v3) branches there.
+
+# Installing
+
+Since FortWrap is pure Python, it is simply installed by running
+
+```bash
+pip install .
+```
+
+from the top level directory (where `setup.py` is found). If you are actively developing FortWrap, use
+
+```bash
+pip install -e .
+```
+
+to create a symlink to the package instead of a hard copy.
 
 ## News
 

--- a/fortwrap.py
+++ b/fortwrap.py
@@ -375,10 +375,17 @@ class DataType(object):
         type_map = cpp_type_map.get(self.type)
         return type_map and self.kind.upper() in type_map
 
+def sanitize_argument_name(name):
+    illegal_names = ['this', 'float', 'double', 'int', 'long', 'nullptr', 'struct', 'new', 'delete']
+    if name in illegal_names:
+        warnings.warn('\n"' + name + '" is an illegal argument name in C++, changing it to "_' + name + '"', RuntimeWarning)
+        name = '_' + name
+    return name
+
 class Argument(object):
     def __init__(self,name,pos,type=None,optional=False,intent='inout',byval=False,allocatable=False,pointer=False,comment=[]):
         global string_class_used
-        self.name = name
+        self.name = sanitize_argument_name(name)
         self.pos = pos # Zero-indexed
         self.type = type
         self.comment = comment

--- a/fortwrap/__main__.py
+++ b/fortwrap/__main__.py
@@ -1,0 +1,3 @@
+from . import fortwrap
+
+fortwrap.wrap()

--- a/fortwrap/fortwrap.py
+++ b/fortwrap/fortwrap.py
@@ -2115,6 +2115,7 @@ def write_pybind11_bindings(classes):
     file.write('#include <pybind11/pybind11.h>\n')
     file.write('#include <pybind11/stl.h>\n')
     file.write('#include <pybind11/numpy.h>\n')
+    file.write('#include <optional>\n')
 
     for cls in classes:
         if cls.name.lower() in name_exclusions:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import imp
+from setuptools import setup
+from pathlib import Path
+from glob import glob
+
+this_dir = Path(__file__).parent
+readme = (this_dir / 'README.md').read_text()
+setup(
+    name='fortwrap',
+    version='2.3.1',
+    packages=['fortwrap'],
+    description='FortWrap is a python script that parses Fortran 90/95/2003 source files and generates wrapper code for '
+                'interfacing with the original Fortran code from C++. FortWrap is intended to be used with Fortran code '
+                'that takes an object oriented approach and makes use of Fortran derived types. The resulting wrapper '
+                'code provides a C++ interface that wraps the Fortran derived types with C++ "proxy classes"',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    author='John McFarland',
+    author_email='mcfarljm@gmail.com',
+    url='https://github.com/mcfarljm/fortwrap'
+)


### PR DESCRIPTION
Edit: We are maintaining a fork at [https://github.com/thermotools](https://github.com/thermotools), and are also automating generation of [pybind11](https://pybind11.readthedocs.io/en/stable/) bindings for the C++ wrapper :)

Hi,

It looks like we may be adopting this for our project :) If we do, we will be maintaining a fork at [https://github.com/thermotools](https://github.com/thermotools).

While I was testing it I made some modifications:

- Added `setup.py` and moved some files so that `pip` can be easily utilized.
- Added sorting of modules before writing `FortranISOWrappers.f90`, so that modules are compiled in order of dependency. Also fixed bug where modules did not properly include each other.
- Added name sanitizing before writing c++ interface, to prevent argument names that are reserved keywords in C++
- Made the `ConfigFile` parser also read command-line arguments
- Added code to generate a binding module for `PyBind11` (still very experimental, may need manual modifications after being generated.)